### PR TITLE
Add trial to complete tcp echo client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vs/
 build/
 out/
+
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .vs/
 build/
 out/
-
+# clangd index cache
 .cache

--- a/example/tcp_echo_client.cpp
+++ b/example/tcp_echo_client.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <string>
 
-#include "salt/log.h"
 #include "salt/packet_assemble.h"
 #include "salt/tcp_client.h"
 #include "salt/version.h"

--- a/example/tcp_echo_client.cpp
+++ b/example/tcp_echo_client.cpp
@@ -35,14 +35,14 @@ int main() {
     }
   });
 
-  while (true) {
+  for (uint32_t i = 0; ; i++) {
     std::string line;
     std::getline(std::cin, line);
     if (line == "quit") {
       break;
     }
 
-    client.broadcast(line, [](auto seq, auto error_code) {
+    client.broadcast(i, line, [](auto seq, auto error_code) {
       std::cout << "send data seq:" << seq
                 << ", with error code:" << error_code.message() << std::endl;
     });

--- a/example/tcp_echo_client.cpp
+++ b/example/tcp_echo_client.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
+#include <string>
 
+#include "salt/log.h"
 #include "salt/packet_assemble.h"
 #include "salt/tcp_client.h"
 #include "salt/version.h"
@@ -14,9 +16,7 @@ public:
   salt::data_read_result
   data_received(std::shared_ptr<salt::connection_handle> connection,
                 std::string s) override {
-    static uint32_t seq = 0;
-    connection->send(++seq, std::move(s), send_call_back);
-
+    std::cout << "received data: " << s.c_str() << std::endl;
     return salt::data_read_result::success;
   }
 };
@@ -36,7 +36,19 @@ int main() {
     }
   });
 
-  std::cin.get();
+  while (true) {
+    std::string line;
+    std::getline(std::cin, line);
+    if (line == "quit") {
+      break;
+    }
+
+    client.broadcast(line, [](auto seq, auto error_code) {
+      std::cout << "send data seq:" << seq
+                << ", with error code:" << error_code.message() << std::endl;
+    });
+  }
+
   client.disconnect("127.0.0.1", 2002, [](const std::error_code &error_code) {
     if (error_code) {
       std::cout << "disconnect to 127.0.0.1:2002 error, reason:"

--- a/src/salt/tcp_client.cpp
+++ b/src/salt/tcp_client.cpp
@@ -125,12 +125,14 @@ void tcp_client::set_assemble_creator(
   assemble_creator_ = assemble_creator;
 }
 
-void tcp_client::broadcast(std::string s, tcp_connection::call_back call_back) {
-  static uint32_t seq = 0;
-  for (auto& connected: connected_) {
-    connected.second->send(seq, s, call_back);
-  }
-  seq++;
+void tcp_client::broadcast(uint32_t seq, std::string s,
+                           tcp_connection::call_back call_back) {
+  control_thread_.get_io_context().post(
+      [this, seq, s = std::move(s), call_back = std::move(call_back)] {
+        for (auto &connected : connected_) {
+          connected.second->send(seq, s, call_back);
+        }
+      });
 }
 
 } // namespace salt

--- a/src/salt/tcp_client.cpp
+++ b/src/salt/tcp_client.cpp
@@ -2,7 +2,6 @@
 
 #include "salt/error.h"
 #include "salt/log.h"
-#include <utility>
 
 namespace salt {
 

--- a/src/salt/tcp_client.h
+++ b/src/salt/tcp_client.h
@@ -53,6 +53,8 @@ public:
   void set_assemble_creator(
       std::function<base_packet_assemble *(void)> assemble_creator);
 
+  void broadcast(std::string, tcp_connection::call_back);
+
   void stop();
 
 private:

--- a/src/salt/tcp_client.h
+++ b/src/salt/tcp_client.h
@@ -53,7 +53,7 @@ public:
   void set_assemble_creator(
       std::function<base_packet_assemble *(void)> assemble_creator);
 
-  void broadcast(std::string, tcp_connection::call_back);
+  void broadcast(uint32_t seq, std::string, tcp_connection::call_back);
 
   void stop();
 

--- a/src/salt/tcp_connection.h
+++ b/src/salt/tcp_connection.h
@@ -14,6 +14,7 @@ namespace salt {
 
 class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
 public:
+  using call_back = std::function<void(uint32_t seq, const std::error_code &)>;
   static std::shared_ptr<tcp_connection>
   create(asio::io_context &transfer_io_context,
          base_packet_assemble *packet_assemble);


### PR DESCRIPTION
```
→ ./tcp_echo_server                                         │→ ./tcp_echo_client
listen ip address:0.0.0.0:2002                              │create tcp_conection:0x7f0964000b90
create tcp_conection:0x55a025a92b10                         │connect to 127.0.0.1:2002 success
server start success, salt version:0.1                      │connected to host:127.0.0.1:2002
accept success                                              │hello
create tcp_conection:0x7fb294000c40                         │send data seq:0, with error code:Success
receive 5 byte data                                         │receive 5 byte data
read data from 127.0.0.1:56414 success, continue read       │received data:hello
send data seq:1, with error code:Success                    │read data from 127.0.0.1:2002 success, continue read
receive 11 byte data                                        │hello world
read data from 127.0.0.1:56414 success, continue read       │send data seq:1, with error code:Success
send data seq:2, with error code:Success                    │receive 11 byte data
                                                            │received data:hello world
                                                            │read data from 127.0.0.1:2002 success, continue read
                                                            │
                                                            │
                                                            │
                                                            │
                                                            │
```